### PR TITLE
GitHub ActionsからNode.js v12を削除

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 16.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
GitHub ActionsからNode.js v12を削除。

実行環境がv16なので削除して問題なし。